### PR TITLE
Capitalize reverse-complement matches in ttl alignment display

### DIFF
--- a/memelite/cli.py
+++ b/memelite/cli.py
@@ -15,6 +15,12 @@ from memelite.utils import one_hot_encode
 from memelite.tomtom import tomtom
 
 
+def _reverse_complement(seq, complement={'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A'}):
+	"""Return the reverse complement of an upper-case ACGT consensus string."""
+
+	return ''.join(complement[c] for c in reversed(seq))
+
+
 def _check_download_targets(targets):
 	"""An internal function for downloading JASPAR if no target database is set."""
 	
@@ -98,6 +104,13 @@ def _run_tomtom(args):
 	for i in numpy.argsort(t_ps):
 		nq = query_pwms[0].shape[-1]
 		seq, offset, overlap = t_seqs[i], t_offsets[i], t_overlaps[i]
+
+		# When the reverse complement is the best match the offset and overlap
+		# are reported in the reverse-complement frame, so display the reverse
+		# complement of the target consensus to keep matches aligned with the
+		# query (and hence shown in upper case).
+		if t_strands[i] == '-':
+			seq = _reverse_complement(seq)
 
 		if overlap == nq and offset >= 0:
 			s1 = seq[:offset].rjust(max_offset)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -212,6 +212,120 @@ def test_run_tomtom_forward_match_is_uppercase(capsys):
 	assert row["aligned_middle"].isupper()
 
 
+def _consensus(name):
+	"""Return the forced consensus sequence of a target in the test database."""
+
+	from memelite.io import read_meme
+	from memelite.utils import characters
+
+	return characters(read_meme("tests/data/test.meme")[name], force=True)
+
+
+def _run_and_get_row(query, name, thresh, capsys):
+	"""Run `_run_tomtom` for a string query and return the row for `name`."""
+
+	args = _tomtom_namespace(query=query, thresh=thresh)
+	_run_tomtom(args)
+	rows = _parse_tomtom_rows(capsys.readouterr().out)
+	return {row["Target Name"]: row for row in rows}[name]
+
+
+def test_run_tomtom_forward_substitution(capsys):
+	# A single substitution on the forward strand lower-cases exactly the
+	# mismatched position; every other aligned position stays upper case and
+	# the upper-cased middle recovers the target consensus.
+	name = "HIC2_MA0738.1"
+	consensus = _consensus(name)            # ATGCCCACC
+	query = consensus[:4] + "T" + consensus[5:]   # substitute position 4
+
+	row = _run_and_get_row(query, name, 0.6, capsys)
+
+	assert row["Strand"] == "+"
+	assert row["Offset"] == "0"
+	assert row["Overlap"] == "9"
+
+	middle = row["aligned_middle"]
+	assert middle == "ATGCcCACC"
+	assert middle.upper() == consensus
+	assert sum(c.islower() for c in middle) == 1
+	assert middle[4].islower()
+
+
+def test_run_tomtom_rc_substitution(capsys):
+	# A single substitution where the reverse complement is the best match:
+	# the mismatch is lower-cased against the reverse-complemented consensus.
+	name = "HIC2_MA0738.1"
+	rc = _reverse_complement(_consensus(name))    # GGTGGGCAT
+	query = rc[:3] + "A" + rc[4:]                  # substitute position 3
+
+	row = _run_and_get_row(query, name, 0.6, capsys)
+
+	assert row["Strand"] == "-"
+	assert row["Offset"] == "0"
+	assert row["Overlap"] == "9"
+
+	middle = row["aligned_middle"]
+	assert middle == "GGTgGGCAT"
+	assert middle.upper() == rc
+	assert sum(c.islower() for c in middle) == 1
+	assert middle[3].islower()
+
+
+def test_run_tomtom_forward_shift(capsys):
+	# A query that is an internal substring of the target aligns at a positive
+	# offset with full overlap and is fully upper case.
+	name = "HIC2_MA0738.1"
+	consensus = _consensus(name)        # ATGCCCACC
+	query = consensus[2:]               # GCCCACC, sits at offset 2
+
+	row = _run_and_get_row(query, name, 0.6, capsys)
+
+	assert row["Strand"] == "+"
+	assert row["Offset"] == "2"
+	assert row["Overlap"] == "7"
+	assert row["aligned_middle"] == query
+	assert row["aligned_middle"].isupper()
+
+
+def test_run_tomtom_right_overhang(capsys):
+	# A query whose tail extends past the right end of the (reverse-complement)
+	# target: the overlapping head is upper case and the hanging tail is padded
+	# with dashes.
+	name = "GCR_HUMAN.H11MO.0.A"
+	consensus = _consensus(name)            # AGAACAGAATGTTCT
+	query = consensus[-5:] + "AAA"          # GTTCTAAA
+
+	row = _run_and_get_row(query, name, 0.9, capsys)
+
+	assert row["Strand"] == "-"
+	assert row["Offset"] == "10"
+	assert row["Overlap"] == "5"
+
+	middle = row["aligned_middle"]
+	assert middle == "GTTCT---"
+	assert middle.endswith("---")
+	assert middle[:5].isupper()
+
+
+def test_run_tomtom_left_overhang(capsys):
+	# A query whose head extends past the left end of the target: the hanging
+	# head is padded with dashes and the overlapping tail is upper case.
+	name = "GCR_HUMAN.H11MO.0.A"
+	consensus = _consensus(name)            # AGAACAGAATGTTCT
+	query = "AAA" + consensus[:5]           # AAAAGAAC
+
+	row = _run_and_get_row(query, name, 0.9, capsys)
+
+	assert row["Strand"] == "+"
+	assert row["Offset"] == "-3"
+	assert row["Overlap"] == "5"
+
+	middle = row["aligned_middle"]
+	assert middle == "---AGAAC"
+	assert middle.startswith("---")
+	assert middle[3:].isupper()
+
+
 def test_run_annotate(tmp_path, capsys):
 	# Each BED row produces one annotated line with a target-database motif.
 	bed = tmp_path / "regions.bed"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -127,6 +127,91 @@ def test_run_tomtom_no_hits(capsys):
 	assert "Query Name" not in out
 
 
+def _reverse_complement(seq):
+	"""Return the reverse complement of an upper-case ACGT string."""
+
+	complement = {'A': 'T', 'C': 'G', 'G': 'C', 'T': 'A'}
+	return ''.join(complement[c] for c in reversed(seq))
+
+
+def _parse_tomtom_rows(out):
+	"""Parse `_run_tomtom` stdout into a list of per-hit field dictionaries.
+
+	The aligned target sequence column contains the match string of the form
+	`prefix.MIDDLE.suffix` where `MIDDLE` is the aligned region with matches in
+	upper case and mismatches in lower case. This helper splits that out so the
+	tests can inspect the capitalisation directly.
+	"""
+
+	lines = out.strip().split("\n")
+	header = lines[0].split("\t")
+
+	rows = []
+	for line in lines[1:]:
+		fields = [f.strip() for f in line.split("\t")]
+		row = dict(zip(header, fields))
+
+		aligned = row["Target Sequence"]
+		row["aligned_middle"] = aligned.split(".")[1]
+		rows.append(row)
+
+	return rows
+
+
+def test_run_tomtom_rc_match_is_uppercase(capsys):
+	# When the reverse complement is the best match, the aligned region should
+	# capitalise the matching positions rather than showing them all as
+	# lower-case mismatches against the forward strand.
+	from memelite.io import read_meme
+	from memelite.utils import characters
+
+	targets = read_meme("tests/data/test.meme")
+
+	# A perfect reverse-complement query for each target whose consensus is
+	# unambiguous: the aligned region must come back fully upper case.
+	cases = ["HIC2_MA0738.1", "PAX7_PAX_2", "TBX19_MA0804.1"]
+
+	for name in cases:
+		consensus = characters(targets[name], force=True)
+		query = _reverse_complement(consensus)
+
+		args = _tomtom_namespace(query=query, thresh=0.5)
+		_run_tomtom(args)
+		rows = _parse_tomtom_rows(capsys.readouterr().out)
+
+		hits = {row["Target Name"]: row for row in rows}
+		assert name in hits, name
+
+		row = hits[name]
+		assert row["Strand"] == "-", name
+
+		# The query is an exact reverse complement, so every aligned position
+		# matches and the middle must equal the query in upper case.
+		assert row["aligned_middle"] == query, (name, row["aligned_middle"])
+		assert row["aligned_middle"].isupper(), (name, row["aligned_middle"])
+
+
+def test_run_tomtom_forward_match_is_uppercase(capsys):
+	# A forward (`+` strand) exact match must likewise capitalise the aligned
+	# region; this guards against the reverse-complement fix breaking the
+	# forward strand.
+	from memelite.io import read_meme
+	from memelite.utils import characters
+
+	targets = read_meme("tests/data/test.meme")
+	name = "HIC2_MA0738.1"
+	query = characters(targets[name], force=True)
+
+	args = _tomtom_namespace(query=query, thresh=0.5)
+	_run_tomtom(args)
+	rows = _parse_tomtom_rows(capsys.readouterr().out)
+
+	row = {r["Target Name"]: r for r in rows}[name]
+	assert row["Strand"] == "+"
+	assert row["aligned_middle"] == query
+	assert row["aligned_middle"].isupper()
+
+
 def test_run_annotate(tmp_path, capsys):
 	# Each BED row produces one annotated line with a target-database motif.
 	bed = tmp_path / "regions.bed"


### PR DESCRIPTION
## Summary

The `ttl` command-line tool shows the alignment between a query and each matched target, capitalizing positions that match and lower-casing mismatches. When the **reverse complement** was the best match, the offset/overlap are reported in the reverse-complement frame but the displayed consensus was still the forward strand — so every aligned position on a `-` strand hit appeared as a lower-case mismatch, even for a perfect match.

Example before the fix (query `GGTGGGCAT` is the exact reverse complement of target consensus `ATGCCCACC`, p=0.00017):

```
. GGTGGGCAT HIC2_MA0738.1 .atgcccacc. 0.00017 724 0 9 -
```

After the fix:

```
. GGTGGGCAT HIC2_MA0738.1 .GGTGGGCAT. 0.00017 724 0 9 -
```

## Changes

- **`memelite/cli.py`** — add a `_reverse_complement` helper and reverse-complement the target consensus before building the alignment string when the best match is on the `-` strand, so minus-strand matches align with the query and render in upper case.

## Tests (`tests/test_cli.py`)

- `test_run_tomtom_rc_match_is_uppercase` / `test_run_tomtom_forward_match_is_uppercase` — exact matches capitalize fully on both strands.
- Imperfect-match coverage to verify shifting/overlap stay correct, with golden values verified stable across repeated runs:
  - forward and RC single **substitutions** (exactly one lower-cased mismatch),
  - a positive-offset substring **shift**,
  - right and left **overhangs** (query hanging off the target edge, dash-padded).

These exercise all three offset/overlap display branches across both strands.

## Test plan

- `python -m pytest -q` → **140 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)