### PR TITLE
FIX negative p-values from tomtom on very good matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `tomtom` no longer returns tiny negative p-values (~ -1e-14 to -1e-11) for
+  very good matches. The p-value is read from a background survival function
+  computed as `1 - cumsum(pdf)`; floating-point round-off in the cumsum over
+  thousands of bins, combined with a distribution that does not sum to exactly
+  1, could push the survival value just below zero at the extreme right tail
+  (i.e. for the best-scoring alignments). `_p_value_backgrounds` now clamps the
+  survival function to be non-negative.
+
 ## [0.3.0]
 
 ### Fixed

--- a/memelite/tomtom.py
+++ b/memelite/tomtom.py
@@ -207,8 +207,14 @@ def _p_value_backgrounds(f, A, B, A_csum, nq, n_bins, t_max, offset):
 		for j in range(1, n):
 			B[i, j] += B[i, j-1]
 		
+		# The cumsum above accumulates floating-point round-off across thousands
+		# of bins and the underlying distribution does not sum to exactly 1, so
+		# at the extreme right tail (the very best matches) the CDF can land just
+		# above 1.0. A survival probability cannot be negative, so clamp the
+		# round-off to zero to avoid returning tiny negative p-values.
 		for j in range(n):
-			B[i, j] = 1 - B[i, j]
+			b = 1 - B[i, j]
+			B[i, j] = b if b > 0 else 0.0
 			
 
 @njit(cache=True)

--- a/tests/test_tomtom.py
+++ b/tests/test_tomtom.py
@@ -703,6 +703,32 @@ def test_tomtom_reverse_complement_merge():
 		1., 0.])
 
 
+def test_tomtom_p_values_non_negative():
+	# Regression test for the small, negative p-values that users reported on
+	# very good matches.
+	#
+	# The p-value of a hit is read straight out of the background survival
+	# function `B` built in `_p_value_backgrounds`, which is formed as
+	# `1 - cumsum(pdf)`. The cumsum accumulates floating-point round-off over
+	# thousands of bins and the underlying distribution does not sum to exactly
+	# 1, so for the very best (highest-scoring) matches -- which land in the
+	# extreme right tail where the CDF is ~1 -- the survival value could come
+	# out as a tiny negative number (~ -1e-14 single strand, roughly doubled by
+	# the `1 - (1 - p) ** 2` reverse-complement merge). A survival probability
+	# can never be negative, so `_p_value_backgrounds` now clamps it to zero.
+	#
+	# A self-comparison of `test.meme` exercises this: every motif's best hit
+	# is itself, sitting in that tail. Pre-fix the diagonal entries were
+	# negative (see the golden values in `test_tomtom_meme`); they must now be
+	# non-negative on both strands.
+	pwms = list(read_meme("tests/data/test.meme").values())
+
+	for rc in (True, False):
+		p, scores, offsets, overlaps, strands = tomtom(pwms, pwms,
+			reverse_complement=rc)
+		assert numpy.all(p >= 0), p.min()
+
+
 def test_tomtom_n_jobs_subsets():
 	pwms = list(read_meme("tests/data/test.meme").values())
 	out1 = tomtom(pwms[:5], pwms, n_jobs=1)


### PR DESCRIPTION
## Summary

Users reported `tomtom` returning small but **negative** p-values (e.g. `-1e-11`) for very good matches. This is a floating-point round-off issue, now fixed by clamping the background survival function to be non-negative.

## Reproducing example

A CTCF-like query matrix against the JASPAR2024 CORE non-redundant database produces negative p-values for its three best hits (all CTCF motifs — the highest-scoring matches):

```
247  MA1930.2 CTCF   p=-1.0951684004112394e-11   score=2109.0
246  MA1929.2 CTCF   p=-1.0289102903016100e-11   score=2068.0
245  MA0139.2 CTCF   p=-4.9169557314598930e-12   score=1904.0
```

Only the three best (highest-scoring) matches are affected; mediocre matches are always comfortably positive. The same effect shows up on a plain `test.meme` self-comparison (every motif's best hit is itself), which is what the regression test uses so no large download is needed.

## Root cause

The p-value of a hit is read straight out of the background **survival function** `B` in `_p_value_backgrounds` (`tomtom.py`), via `_p_values`:

```python
results[i, 0] = B_cdfs[nt, uint64(score-1)]
```

`B` is constructed as `1 - cumsum(pdf)`:

```python
for i in range(B.shape[0]):
    for j in range(1, n):
        B[i, j] += B[i, j-1]      # CDF via cumsum over ~thousands of bins
    for j in range(n):
        B[i, j] = 1 - B[i, j]     # survival function P(X >= score)
```

The underlying score distribution comes from `f[i, x] += Y_counts[j] / ys` convolved repeatedly by `_pairwise_max`. None of these sum to *exactly* 1.0 in float64, and the cumsum accumulates round-off across thousands of bins. At the **extreme right tail** — i.e. for the best-scoring matches — the CDF lands at `1.0 + ~2.8e-12`, so `1 - CDF` is a tiny negative number. For mediocre matches the CDF is well below 1, so they are never affected. That is why this only appears for *very good matches*.

**Two propagation paths from the single source:**
- `reverse_complement=False`: `_p_values` returns the negative `B` value directly → p ≈ `-2.8e-12`.
- `reverse_complement=True` (default): `_merge_rc_results` takes `min` of the two strands then `p = 1 - (1 - p)**2 ≈ 2p`, roughly doubling it → p ≈ `-1.1e-11`.

Confirmed empirically that the negatives already exist **before** the RC merge, so the merge is not the cause — it just propagates and amplifies.

## Fix

Clamp the survival function to be non-negative at the source in `_p_value_backgrounds`. A survival probability / p-value can never be negative, so clamping the round-off to zero is conceptually correct, not a hack. This single change covers both the RC and no-RC paths:

```python
for j in range(n):
    b = 1 - B[i, j]
    B[i, j] = b if b > 0 else 0.0
```

## Testing

- New regression test `test_tomtom_p_values_non_negative` asserts all p-values are `>= 0` on a `test.meme` self-comparison for both strands. Verified it **fails before** the fix (`-7.5e-14`) and **passes after** (TDD).
- Full suite: 141 passed. Existing golden values that contained these tiny negatives (e.g. `test_tomtom_meme`'s `-1.687538e-14`) still pass since they are compared at 4–6 decimals, where the clamped `0.0` is indistinguishable from the old round-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)